### PR TITLE
Actualización SET_TIM4

### DIFF
--- a/src/mi_libreria.c
+++ b/src/mi_libreria.c
@@ -472,7 +472,10 @@ void SET_TIM4(uint16_t Pin, uint32_t TimeBase, uint32_t Freq, uint32_t DutyCycle
 	uint32_t DT_Value;
 	uint16_t PrescalerValue = 0;
 
+	//Actualización de los valores del TIM4:
 	SystemCoreClockUpdate();
+	TIM_ARRPreloadConfig(TIM4, DISABLE);
+	TIM_Cmd(TIM4, DISABLE);
 
 	/* Compute the prescaler value */
 	PrescalerValue = (uint16_t) ((SystemCoreClock / 2) / TimeBase) - 1;


### PR DESCRIPTION
- Se crearon instrucciones para actualizar los valores del TIM4 con el objetivo de poder crear un PWM dinámico.